### PR TITLE
Add floating link to dashboard

### DIFF
--- a/Color_Picker_Game.html
+++ b/Color_Picker_Game.html
@@ -29,6 +29,18 @@
     #summaryTable { border-collapse: collapse; margin: 20px auto; width: 90%; }
     #summaryTable th, #summaryTable td { border: 1px solid #ccc; padding: 8px; }
     footer { margin-top: 40px; font-size: 0.9em; }
+    .floating-btn {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background-color: #007bff;
+      color: #fff;
+      padding: 10px 15px;
+      border-radius: 5px;
+      text-decoration: none;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+      z-index: 1000;
+    }
   </style>
 </head>
 <body>
@@ -311,5 +323,6 @@
       link.click();
     }
   </script>
+  <a href="dashboard.html" class="floating-btn">Dashboard</a>
 </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -10,6 +10,18 @@
     body { font-family: Arial, sans-serif; padding: 20px; text-align: center; }
     table { border-collapse: collapse; margin: 20px auto; width: 90%; }
     th, td { border: 1px solid #ccc; padding: 8px; }
+    .floating-btn {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background-color: #007bff;
+      color: #fff;
+      padding: 10px 15px;
+      border-radius: 5px;
+      text-decoration: none;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+      z-index: 1000;
+    }
   </style>
 </head>
 <body>
@@ -87,5 +99,6 @@ function loadDashboard() {
 }
 loadDashboard();
 </script>
+<a href="dashboard.html" class="floating-btn">Dashboard</a>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,18 @@
     #summaryTable { border-collapse: collapse; margin: 20px auto; width: 90%; }
     #summaryTable th, #summaryTable td { border: 1px solid #ccc; padding: 8px; }
     footer { margin-top: 40px; font-size: 0.9em; }
+    .floating-btn {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background-color: #007bff;
+      color: #fff;
+      padding: 10px 15px;
+      border-radius: 5px;
+      text-decoration: none;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+      z-index: 1000;
+    }
   </style>
 </head>
 <body>
@@ -311,5 +323,6 @@
       link.click();
     }
   </script>
+  <a href="dashboard.html" class="floating-btn">Dashboard</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a floating button style used across the site
- link to `dashboard.html` from all pages using the floating button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68651e832e38832692547f78e4d18705