### PR TITLE
Add unload warning for active sessions

### DIFF
--- a/Color_Picker_Game.html
+++ b/Color_Picker_Game.html
@@ -310,6 +310,14 @@
       link.download = `psi_color_picker_results_${Date.now()}.csv`;
       link.click();
     }
+
+    // Warn the user if they attempt to leave in the middle of a session
+    window.addEventListener('beforeunload', (e) => {
+      if (role && trialNum < maxTrials) {
+        e.preventDefault();
+        e.returnValue = 'You are leaving an active session and the trial will not be complete.';
+      }
+    });
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -310,6 +310,14 @@
       link.download = `psi_color_picker_results_${Date.now()}.csv`;
       link.click();
     }
+
+    // Warn the user if they attempt to leave in the middle of a session
+    window.addEventListener('beforeunload', (e) => {
+      if (role && trialNum < maxTrials) {
+        e.preventDefault();
+        e.returnValue = 'You are leaving an active session and the trial will not be complete.';
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `beforeunload` event handler in game pages

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68651eccfd7c83268de3e8bb6cd568fe