### PR TITLE
Create floating menu with home and dashboard links

### DIFF
--- a/Color_Picker_Game.html
+++ b/Color_Picker_Game.html
@@ -29,17 +29,35 @@
     #summaryTable { border-collapse: collapse; margin: 20px auto; width: 90%; }
     #summaryTable th, #summaryTable td { border: 1px solid #ccc; padding: 8px; }
     footer { margin-top: 40px; font-size: 0.9em; }
-    .floating-btn {
+    .floating-menu {
       position: fixed;
       bottom: 20px;
       right: 20px;
+      z-index: 1000;
+    }
+    .floating-menu button {
       background-color: #007bff;
       color: #fff;
       padding: 10px 15px;
+      border: none;
       border-radius: 5px;
-      text-decoration: none;
       box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-      z-index: 1000;
+    }
+    .floating-menu-links {
+      display: none;
+      margin-top: 5px;
+      background-color: #007bff;
+      border-radius: 5px;
+      overflow: hidden;
+    }
+    .floating-menu-links a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      padding: 10px 15px;
+    }
+    .floating-menu-links a + a {
+      border-top: 1px solid rgba(255,255,255,0.3);
     }
   </style>
 </head>
@@ -330,7 +348,18 @@
         e.returnValue = 'You are leaving an active session and the trial will not be complete.';
       }
     });
+
+    function toggleMenu() {
+      const links = document.getElementById('menuLinks');
+      links.style.display = links.style.display === 'block' ? 'none' : 'block';
+    }
   </script>
-  <a href="dashboard.html" class="floating-btn">Dashboard</a>
+  <div class="floating-menu">
+    <button id="menuBtn" onclick="toggleMenu()">Menu</button>
+    <div id="menuLinks" class="floating-menu-links">
+      <a href="index.html">Home</a>
+      <a href="dashboard.html">Dashboard</a>
+    </div>
+  </div>
 </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -10,17 +10,35 @@
     body { font-family: Arial, sans-serif; padding: 20px; text-align: center; }
     table { border-collapse: collapse; margin: 20px auto; width: 90%; }
     th, td { border: 1px solid #ccc; padding: 8px; }
-    .floating-btn {
+    .floating-menu {
       position: fixed;
       bottom: 20px;
       right: 20px;
+      z-index: 1000;
+    }
+    .floating-menu button {
       background-color: #007bff;
       color: #fff;
       padding: 10px 15px;
+      border: none;
       border-radius: 5px;
-      text-decoration: none;
       box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-      z-index: 1000;
+    }
+    .floating-menu-links {
+      display: none;
+      margin-top: 5px;
+      background-color: #007bff;
+      border-radius: 5px;
+      overflow: hidden;
+    }
+    .floating-menu-links a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      padding: 10px 15px;
+    }
+    .floating-menu-links a + a {
+      border-top: 1px solid rgba(255,255,255,0.3);
     }
   </style>
 </head>
@@ -99,6 +117,18 @@ function loadDashboard() {
 }
 loadDashboard();
 </script>
-<a href="dashboard.html" class="floating-btn">Dashboard</a>
+<script>
+  function toggleMenu() {
+    const links = document.getElementById('menuLinks');
+    links.style.display = links.style.display === 'block' ? 'none' : 'block';
+  }
+</script>
+<div class="floating-menu">
+  <button id="menuBtn" onclick="toggleMenu()">Menu</button>
+  <div id="menuLinks" class="floating-menu-links">
+    <a href="index.html">Home</a>
+    <a href="dashboard.html">Dashboard</a>
+  </div>
+</div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -29,17 +29,35 @@
     #summaryTable { border-collapse: collapse; margin: 20px auto; width: 90%; }
     #summaryTable th, #summaryTable td { border: 1px solid #ccc; padding: 8px; }
     footer { margin-top: 40px; font-size: 0.9em; }
-    .floating-btn {
+    .floating-menu {
       position: fixed;
       bottom: 20px;
       right: 20px;
+      z-index: 1000;
+    }
+    .floating-menu button {
       background-color: #007bff;
       color: #fff;
       padding: 10px 15px;
+      border: none;
       border-radius: 5px;
-      text-decoration: none;
       box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-      z-index: 1000;
+    }
+    .floating-menu-links {
+      display: none;
+      margin-top: 5px;
+      background-color: #007bff;
+      border-radius: 5px;
+      overflow: hidden;
+    }
+    .floating-menu-links a {
+      color: #fff;
+      text-decoration: none;
+      display: block;
+      padding: 10px 15px;
+    }
+    .floating-menu-links a + a {
+      border-top: 1px solid rgba(255,255,255,0.3);
     }
   </style>
 </head>
@@ -330,7 +348,18 @@
         e.returnValue = 'You are leaving an active session and the trial will not be complete.';
       }
     });
+
+    function toggleMenu() {
+      const links = document.getElementById('menuLinks');
+      links.style.display = links.style.display === 'block' ? 'none' : 'block';
+    }
   </script>
-  <a href="dashboard.html" class="floating-btn">Dashboard</a>
+  <div class="floating-menu">
+    <button id="menuBtn" onclick="toggleMenu()">Menu</button>
+    <div id="menuLinks" class="floating-menu-links">
+      <a href="index.html">Home</a>
+      <a href="dashboard.html">Dashboard</a>
+    </div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace single Dashboard floating button with a menu showing Home and Dashboard links
- add toggleMenu script and styling for the new floating menu

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865205d85608326a158a85929178374